### PR TITLE
fix: id not being return on getContractorsByServiceId

### DIFF
--- a/queries/contractor.js
+++ b/queries/contractor.js
@@ -47,7 +47,7 @@ const getContractorByID = async (id) => {
 const getContractorsByServiceId = async (serviceId) => {
   try {
     const contractors = await db.any(
-      "SELECT contractors.name, contractors.description, contractors.location\
+      "SELECT contractors.id, contractors.name, contractors.description, contractors.location\
       FROM contractors\
       JOIN contractors_services\
       ON contractors.id = contractors_services.contractor_id\


### PR DESCRIPTION
Fix: Not returning the id caused not being able to pull the contractor's data when searching.